### PR TITLE
DockerHubのリポジトリ名のenvを変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ jobs:
     - stage: push
       language: minimal
       if: tag =~ ^v
-      env:
-        - IMAGE_NAME=ktmouk/hackaru-web
       services:
         - docker
       script:
@@ -38,6 +36,6 @@ jobs:
             "$(echo "$TRAVIS_TAG" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+)$/\1.\2.\3/')" \
           )
           for TAG in ${TAGS[@]}; do
-            docker build . -t "$IMAGE_NAME:$TAG"
-            docker push "$IMAGE_NAME:$TAG"
+            docker build . -t "$DOCKER_REPO_NAME:$TAG"
+            docker push "$DOCKER_REPO_NAME:$TAG"
           done

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![jest](https://jestjs.io/img/jest-badge.svg)](https://github.com/facebook/jest)
 [![Build Status](https://travis-ci.org/ktmouk/hackaru-web.svg?branch=master)](https://travis-ci.org/ktmouk/hackaru-web)
-[![Maintainability](https://api.codeclimate.com/v1/badges/fd01121360a3fd652411/maintainability)](https://codeclimate.com/github/ktmouk/hackaru-web/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/fd01121360a3fd652411/test_coverage)](https://codeclimate.com/github/ktmouk/hackaru-web/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/f3acee4ccf10e43f8cd7/maintainability)](https://codeclimate.com/github/hackaru-app/hackaru-web/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/f3acee4ccf10e43f8cd7/test_coverage)](https://codeclimate.com/github/hackaru-app/hackaru-web/test_coverage)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 <br>


### PR DESCRIPTION
- DockerHubのリポジトリ名の設定を `$DOCKER_REPO_NAME` で設定するように変更。
- 実際の値はTravisCIの設定画面の環境変数で設定するように変更。