### PR TITLE
Suggestの件数を最大30件に変更

### DIFF
--- a/__tests__/store/suggestions/actions.spec.js
+++ b/__tests__/store/suggestions/actions.spec.js
@@ -16,7 +16,7 @@ describe('Actions', () => {
           url: '/v1/suggestions',
           params: {
             q: 'query',
-            limit: 6
+            limit: 30
           }
         },
         { root: true }

--- a/components/organisms/timer-form.vue
+++ b/components/organisms/timer-form.vue
@@ -329,6 +329,7 @@ export default {
   overflow-y: scroll;
   box-shadow: 0 3px 5px $shadow-darker;
   -webkit-overflow-scrolling: touch;
+  max-height: 395px;
 }
 .suggestion-list ul {
   margin: 0;
@@ -345,13 +346,6 @@ export default {
   padding: 0 45px;
   border-bottom: 1px $border solid;
   transition: background-color 0.1s ease;
-  &:last-child {
-    border-bottom: 0;
-    padding-bottom: 10px;
-  }
-  &:first-child {
-    padding-top: 10px;
-  }
   &:hover {
     background-color: $background-hover;
   }

--- a/store/suggestions.js
+++ b/store/suggestions.js
@@ -13,7 +13,7 @@ export const actions = {
           url: '/v1/suggestions',
           params: {
             q,
-            limit: 6
+            limit: 30
           }
         },
         { root: true }


### PR DESCRIPTION
- 最大5件から30件に変更。
- `max-height` を設定して件数が多い場合はスクロールするようにした。