### PR TITLE
TimerFormのheightを調整

### DIFF
--- a/components/organisms/timer-form.vue
+++ b/components/organisms/timer-form.vue
@@ -436,6 +436,7 @@ export default {
     background-color: $background-translucent;
     box-shadow: 0 3px 3px $shadow inset;
     max-height: 100%;
+    padding-bottom: 550px;
   }
   .suggestion-list ul {
     min-height: 130vh;

--- a/components/organisms/timer-form.vue
+++ b/components/organisms/timer-form.vue
@@ -435,6 +435,7 @@ export default {
     max-width: 100vw;
     background-color: $background-translucent;
     box-shadow: 0 3px 3px $shadow inset;
+    max-height: 100%;
   }
   .suggestion-list ul {
     min-height: 130vh;

--- a/components/organisms/timer-form.vue
+++ b/components/organisms/timer-form.vue
@@ -232,7 +232,7 @@ export default {
   justify-content: center;
   max-width: calc(100vw - #{$side-bar-min-width});
   z-index: index($z, timer-form);
-  height: 90px;
+  height: 91px;
 }
 .duration.stopped {
   color: $text-light;
@@ -316,7 +316,7 @@ export default {
   animation-duration: 100ms;
   width: 100%;
   height: 100vh;
-  top: 90px;
+  top: 91px;
   box-sizing: border-box;
   max-width: calc(100vw - #{$side-bar-min-width});
   background-color: $backdrop-color;


### PR DESCRIPTION
- TimerFormのheightが1pxずれていたのを修正。
- サジェストの下部の余白を追加。